### PR TITLE
Fix commonjs import for neynar sdk

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,8 @@ import cors from "cors";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import { ethers } from "ethers";
-import { NeynarAPIClient, Configuration } from "@neynar/nodejs-sdk";
+import pkg from "@neynar/nodejs-sdk";
+const { NeynarAPIClient, Configuration } = pkg;
 import axios from "axios";
 
 dotenv.config();


### PR DESCRIPTION
Fix `SyntaxError: Named export 'Configuration' not found` by correctly importing the CommonJS `@neynar/nodejs-sdk` module in an ES module environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-96b05726-e439-447d-9114-9a82526767bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96b05726-e439-447d-9114-9a82526767bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

